### PR TITLE
feat: dadbod support

### DIFF
--- a/lua/config/keymaps.lua
+++ b/lua/config/keymaps.lua
@@ -39,3 +39,9 @@ map("n", "<leader>q", "<cmd>q<CR>", { desc = "Quit Window" })
 -- Split window keymaps
 vim.keymap.set("n", "<leader>|", ":vsplit<CR>", { desc = "Vertical split" })
 vim.keymap.set("n", "<leader>,", ":split<CR>", { desc = "Horizontal split" })
+
+--SQL
+vim.keymap.set("n", "<leader>Db", ":DBUI<CR>", { desc = "Open Database UI" })
+vim.keymap.set("n", "<leader>Dt", ":DBUIToggle<CR>", { desc = "Toggle Database UI" })
+vim.keymap.set("n", "<leader>Da", ":DBUIAddConnection<CR>", { desc = "Add Database Connection" })
+vim.keymap.set("n", "<leader>Df", ":DBUIFindBuffer<CR>", { desc = "Find Database Buffer" })

--- a/lua/config/lazy.lua
+++ b/lua/config/lazy.lua
@@ -15,17 +15,20 @@ if not (vim.uv or vim.loop).fs_stat(lazypath) then
 end
 vim.opt.rtp:prepend(lazypath)
 
+local imports = {
+	{ import = "plugins.ai" }, -- AI plugins
+	{ import = "plugins.ui" }, -- UI plugins
+	{ import = "plugins.themes" }, -- Theme plugins
+	{ import = "plugins.editor" }, -- Editor enhancements
+	{ import = "plugins.lsp" }, -- LSP and completion plugins
+	{ import = "plugins.dap" }, -- Debugging plugins
+	{ import = "plugins.sql" }, -- SQL plugins
+	{ import = "plugins" },
+}
+
 -- Setup lazy.nvim
 require("lazy").setup({
-	spec = {
-		{ import = "plugins.ai" }, -- ai plugins
-		{ import = "plugins.ui" }, -- UI plugins
-		{ import = "plugins.themes" }, -- Theme plugins
-		{ import = "plugins.editor" }, -- editor enhancements
-		{ import = "plugins.lsp" }, -- LSP and completion plugins
-		{ import = "plugins.dap" }, -- Debugging plugins
-		{ import = "plugins" },
-	},
+	spec = imports,
 	-- Configure any other settings here. See the documentation for more details.
 	-- colorscheme that will be used when installing plugins.
 	install = { colorscheme = { "habamax" } },

--- a/lua/config/userconfig.lua
+++ b/lua/config/userconfig.lua
@@ -14,6 +14,7 @@ M.config = {
 		"python",
 		"golang",
 		"web", --javascript, typescript
+		"sql",
 	},
 	extras = {
 		enable_godot = false,

--- a/lua/plugins/snacks.lua
+++ b/lua/plugins/snacks.lua
@@ -276,13 +276,13 @@ return {
 			end,
 			desc = "Buffer Lines",
 		},
-		{
-			"<leader>fgb",
-			function()
-				Snacks.picker.grep_buffers()
-			end,
-			desc = "Grep Open Buffers",
-		},
+		-- {
+		-- 	"<leader>fgb",
+		-- 	function()
+		-- 		Snacks.picker.grep_buffers()
+		-- 	end,
+		-- 	desc = "Grep Open Buffers",
+		-- },
 		{
 			"<leader>fg",
 			function()

--- a/lua/plugins/sql/dadbod.lua
+++ b/lua/plugins/sql/dadbod.lua
@@ -1,0 +1,36 @@
+if not vim.tbl_contains(_G["userconfig"].languages, "sql") then
+	return {}
+end
+
+return {
+	{
+		"kristijanhusak/vim-dadbod-ui",
+		dependencies = {
+			{ "tpope/vim-dadbod", lazy = true },
+			{ "kristijanhusak/vim-dadbod-completion", ft = { "sql", "plsql" }, lazy = true }, -- Optional
+		},
+		cmd = {
+			"DBUI",
+			"DBUIToggle",
+			"DBUIAddConnection",
+			"DBUIFindBuffer",
+		},
+		init = function()
+			-- Your DBUI configuration
+			vim.g.db_ui_use_nerd_fonts = 1
+		end,
+	},
+	{ --optional saghen/blink.cmp completion source
+		"saghen/blink.cmp",
+		opts = {
+			sources = {
+				per_filetype = {
+					sql = { "snippets", "dadbod", "buffer" },
+				},
+				providers = {
+					dadbod = { name = "Dadbod", module = "vim_dadbod_completion.blink" },
+				},
+			},
+		},
+	},
+}


### PR DESCRIPTION
This pull request introduces SQL-related functionality to the configuration, including new plugins, keybindings, and language support. It also refactors plugin imports for better organization and removes an unused keybinding from the `snacks.lua` configuration.

### SQL Integration:

* [`lua/plugins/sql/dadbod.lua`](diffhunk://#diff-94de6fecddbcce4cfc00781e1e408c63587d9c52d388688d0b8d0e256a7fe32dR1-R36): Added support for SQL-related plugins, including `vim-dadbod-ui`, `vim-dadbod-completion`, and optional `saghen/blink.cmp` for SQL-specific completion. Includes configuration for database UI commands and completion sources.
* [`lua/config/userconfig.lua`](diffhunk://#diff-2e74b2b0ef1193bf3cecbf981a290dd5bffb89224162fe4ca3db57f7b1a5d523R17): Added `"sql"` to the list of supported languages in the user configuration.
* [`lua/config/keymaps.lua`](diffhunk://#diff-92f43ba44d4cfab6084f7614e53be9d3be8d8172e37bbe45dbda7778f01bb0aeR42-R47): Added keybindings for database operations, such as opening the Database UI (`<leader>Db`), toggling it (`<leader>Dt`), adding connections (`<leader>Da`), and finding buffers (`<leader>Df`).

### Plugin Refactoring:

* [`lua/config/lazy.lua`](diffhunk://#diff-0576a4701375428f926ebc9c273b0700db26d5b50bf3bcb939eecceeb52bbd49L18-R31): Refactored plugin imports into a local `imports` table for better readability and added a new category for SQL plugins.

### Cleanup:

* [`lua/plugins/snacks.lua`](diffhunk://#diff-9c18067df31f03d6d1a703f3f9f718c92c54322355ea9f3070201e2b841b71ddL279-R285): Commented out the keybinding for "Grep Open Buffers" (`<leader>fgb`) as it is no longer used.